### PR TITLE
WIP: Colony game example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = {version = "1.0", features = ["derive"], optional = true}
 
 [dev-dependencies]
 assert_float_eq = "1"
+rand = "0.8.5"
 
 [features]
 serde = ["dep:serde", "ndarray/serde"]

--- a/adr/03_collections.md
+++ b/adr/03_collections.md
@@ -1,0 +1,22 @@
+# Collections
+
+## Status
+
+Accepted
+
+## Context
+
+When utilizing the library with a library defined storage schema becomes cumbersome when writing function definitions that pass the storage schema as an argument. This is also a very common occurence so is a giant pain point when interfacing with the library API. An example of the old `pub fn example(grid: HexGrid<i32, (), ()>) {}`. Another factor is what about application code that doesn't want vertex and/or edge support, it ends up being bloat.
+
+## Decision
+
+Removing the library authored storage schema in favor of traits that the library requires of a storage schema.
+
+## Consequences
+
+### Ease
+- This allows the application code to look and feel nicer while hiding many of the ugliness inside the domain of the library.
+- Modularity and customizable data structures in application code.
+### Pain
+- There is an extra step in application code to define a custom storage schema and implement the traits neccesary.
+- Library code can end up being more complex when interfacing with this collection.

--- a/examples/colony_game/game_types.rs
+++ b/examples/colony_game/game_types.rs
@@ -1,0 +1,156 @@
+use std::collections::HashMap;
+
+use gridava::hex::{coordinate::Axial, edge::Edge, vertex::Vertex};
+
+#[derive(Clone, Debug)]
+pub enum GameError {
+    InvalidLocation,
+    NotEnoughResources,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Default)]
+pub enum TileType {
+    #[default]
+    Desert,
+    Plains,
+    Farmland,
+    Forest,
+    Quarry,
+    Mountain,
+}
+
+impl From<ResourceType> for TileType {
+    fn from(value: ResourceType) -> Self {
+        match value {
+            ResourceType::Lumber => TileType::Forest,
+            ResourceType::Brick => TileType::Quarry,
+            ResourceType::Wool => TileType::Plains,
+            ResourceType::Grain => TileType::Farmland,
+            ResourceType::Ore => TileType::Mountain,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GameTile {
+    pub tile_type: TileType,
+    pub number: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum DevType {
+    None,
+    House,
+    City,
+}
+
+#[derive(Clone, Debug)]
+pub struct GameVert {
+    pub vert_type: DevType,
+    pub owning_player: usize,
+}
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub enum EdgeType {
+    None,
+    Road,
+}
+
+#[derive(Clone, Debug)]
+pub struct GameEdge {
+    pub edge_type: EdgeType,
+    pub owning_player: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct GameBoard {
+    pub tiles: HashMap<Axial, GameTile>,
+    pub edges: HashMap<Edge, GameEdge>,
+    pub verts: HashMap<Vertex, GameVert>,
+    pub robber_tile: Axial,
+}
+
+#[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
+pub enum ResourceType {
+    Lumber,
+    Brick,
+    Wool,
+    Grain,
+    Ore,
+}
+pub const RESOURCE_TYPE_NUM: usize = ResourceType::Ore as usize + 1;
+
+impl TryFrom<TileType> for ResourceType {
+    type Error = String;
+
+    fn try_from(value: TileType) -> Result<Self, Self::Error> {
+        match value {
+            TileType::Desert => Err("Desert does not have a resource".to_string()),
+            TileType::Plains => Ok(ResourceType::Wool),
+            TileType::Farmland => Ok(ResourceType::Grain),
+            TileType::Forest => Ok(ResourceType::Lumber),
+            TileType::Quarry => Ok(ResourceType::Brick),
+            TileType::Mountain => Ok(ResourceType::Ore),
+        }
+    }
+}
+
+impl TryFrom<usize> for ResourceType {
+    type Error = String;
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(ResourceType::Lumber),
+            1 => Ok(ResourceType::Brick),
+            2 => Ok(ResourceType::Wool),
+            3 => Ok(ResourceType::Grain),
+            4 => Ok(ResourceType::Ore),
+            _ => Err("Invalid input".to_string()),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum PurchaseType {
+    Road,
+    House,
+    City,
+    DevCard,
+}
+pub const PURCHASE_TYPE_NUM: usize = PurchaseType::DevCard as usize + 1;
+
+pub const COST_TABLE: [[u32; RESOURCE_TYPE_NUM]; PURCHASE_TYPE_NUM] = [
+    [1, 1, 0, 0, 0], // Road
+    [1, 1, 1, 1, 0], // House
+    [0, 0, 0, 2, 3], // City
+    [0, 0, 1, 1, 1], // DevCard
+];
+
+#[derive(Clone, Debug, Default)]
+pub struct Player {
+    pub resources: [u32; RESOURCE_TYPE_NUM],
+    pub id: usize,
+}
+
+pub const TILE_POOL: [TileType; 19] = [
+    TileType::Plains,
+    TileType::Plains,
+    TileType::Plains,
+    TileType::Plains,
+    TileType::Forest,
+    TileType::Forest,
+    TileType::Forest,
+    TileType::Forest,
+    TileType::Farmland,
+    TileType::Farmland,
+    TileType::Farmland,
+    TileType::Farmland,
+    TileType::Quarry,
+    TileType::Quarry,
+    TileType::Quarry,
+    TileType::Mountain,
+    TileType::Mountain,
+    TileType::Mountain,
+    TileType::Desert,
+];
+
+pub const NUMBER_POOL: [u32; 18] = [2, 3, 3, 4, 4, 5, 5, 6, 6, 8, 8, 9, 9, 10, 10, 11, 11, 12];

--- a/examples/colony_game/main.rs
+++ b/examples/colony_game/main.rs
@@ -1,0 +1,257 @@
+pub mod game_types;
+
+use game_types::*;
+use gridava::core::collection::Collection;
+
+use gridava::hex::edge::Edge;
+use gridava::hex::vertex::Vertex;
+use gridava::{axial, hex::coordinate::Axial, hex::shape::HexShape};
+use rand::Rng;
+use rand::{seq::IteratorRandom, seq::SliceRandom, thread_rng};
+
+use crate::{GameTile, TileType, COST_TABLE, NUMBER_POOL, TILE_POOL};
+
+impl Collection<Axial, GameTile> for GameBoard {
+    fn set(&mut self, coord: Axial, data: GameTile) {
+        self.tiles.insert(coord, data);
+    }
+}
+
+/// This example provides real world applications of the library in the context of a colony board game.
+/// For the sake of brevity, the application will provide mainly examples of how the game logic will
+/// interact with the library. i.e. How to generate an island or calculate longest road.
+/// The example in this repository won't have fully functioning graphics or a game loop.
+fn main() {
+    let mut rng = thread_rng();
+    // Declare our application specific data storage, GameBoard struct
+    let mut game_board = GameBoard::default();
+
+    // Declare a dummy array of 'players' for our colony game.
+    let mut player_array: Vec<Player> = vec![
+        Player {
+            resources: Default::default(),
+            id: 0,
+        },
+        Player {
+            resources: Default::default(),
+            id: 1,
+        },
+    ];
+
+    // Generate an island as a HexShape and apply that HexShape into our long term data storage.
+    generate_island().apply_shape(&mut game_board);
+    game_board.robber_tile = game_board
+        .tiles
+        .iter()
+        .find(|&(_, tile)| tile.tile_type == TileType::Desert)
+        .map(|(coord, _)| *coord)
+        .expect("There should always be at minimum 1 desert tile on the board.");
+
+    // Roll 2d6 and sum them together to figure out the next phase of the game.
+    let roll = rng.gen_range(2..=12);
+
+    // If a 7 is rolled, activate and move the robber; no resource collection.
+    if roll == 7 {
+        game_board.robber_tile = *game_board
+            .tiles
+            .keys()
+            .choose(&mut rng)
+            .unwrap_or(&axial!(2, 2));
+    } else {
+        // Otherwise collect resources with the roll result
+        collect_resources(roll, &game_board, &mut player_array[0]);
+    }
+}
+
+pub fn generate_island() -> HexShape<GameTile> {
+    // Begin: Setting up random pool iterators
+    let mut rng = thread_rng();
+
+    let mut shuffled_tile_pool = TILE_POOL;
+    shuffled_tile_pool.shuffle(&mut rng);
+
+    let mut shuffled_number_pool = NUMBER_POOL;
+    shuffled_number_pool.shuffle(&mut rng);
+
+    let mut tile_pool_iter = shuffled_tile_pool.into_iter();
+    let mut number_pool_iter = shuffled_number_pool.into_iter();
+    // End: Setting up random pool iterators
+
+    // Fill in the island. Tile pool is 19 long because we add a desert tile, and number pool is 18 long because we have to ensure
+    //  the desert tile has an unreachable number roll by a 2d6 like 0.
+    HexShape::make_hexagon(2, 0, true, |_| match tile_pool_iter.next() {
+        Some(TileType::Desert) => GameTile {
+            tile_type: TileType::Desert,
+            number: 0,
+        },
+        Some(tile_type) => GameTile {
+            tile_type,
+            number: number_pool_iter
+                .next()
+                .expect("Number pool ran out before tile pool"),
+        },
+        None => unreachable!("Tile pool ran out unexpectedly"),
+    })
+}
+
+/// Collect resources from the board given a roll and award it to the player.
+pub fn collect_resources(roll: u32, board: &GameBoard, player: &mut Player) {
+    let pid = player.id;
+    board
+        // First we filter the storage for any tile that contains the rolled number, and does not have a robber on it since that does not give resources.
+        .tiles
+        .iter()
+        .filter(|(coord, tile_data)| tile_data.number == roll && **coord != board.robber_tile)
+        .flat_map(|(coord, tile_data)| {
+            // Then we filter based on vertices that are owned by the player and have a development on them.
+            coord.vertices().into_iter().filter_map(move |vert| {
+                board
+                    .verts
+                    .get(&vert)
+                    .filter(|vert_data| {
+                        vert_data.owning_player == pid && vert_data.vert_type != DevType::None
+                    })
+                    // We then combine the tile_data and vert_data into a single iterator for processing
+                    .map(|vert_data| (tile_data, vert_data))
+            })
+        })
+        // For each vertice that has a development on a tile that gives resources do this logic.
+        .for_each(|(tile_data, vert_data)| {
+            // This should always be Ok since it should be impossible to roll a 0 from 2d6, which is the desert tile, and desert tile is what
+            // will cause the try_into to fail. But for completeness we'll do proper error checking here.
+            if let Ok(resource_type) = TryInto::<ResourceType>::try_into(tile_data.tile_type) {
+                // Determine the increment amount based on the development type.
+                let increment = match vert_data.vert_type {
+                    DevType::None => 0,
+                    DevType::House => 1,
+                    DevType::City => 2,
+                };
+                // Award resources to the player
+                player.resources[resource_type as usize] += increment;
+            }
+        });
+}
+
+/// Check if we have the resources to purchase an upgrade.
+pub fn can_purchase(ty: PurchaseType, player: &Player) -> bool {
+    COST_TABLE[ty as usize]
+        .iter()
+        .enumerate()
+        .all(|(i, amount)| player.resources[i] >= *amount)
+}
+
+/// Remove resources from our player stockpile
+pub fn remove_resources(ty: PurchaseType, player: &mut Player) {
+    COST_TABLE[ty as usize]
+        .iter()
+        .enumerate()
+        .for_each(|(i, amount)| {
+            player.resources[i] -= amount;
+        });
+}
+
+/// Purchase an upgrade
+///
+/// Supplied predicate pred is used to mutate player or board state after purchase is finalized.
+pub fn purchase<F>(ty: PurchaseType, player: &mut Player, mut pred: F) -> Result<(), GameError>
+where
+    F: FnMut(),
+{
+    if can_purchase(ty, player) {
+        remove_resources(ty, player);
+        pred();
+        Ok(())
+    } else {
+        Err(GameError::NotEnoughResources)
+    }
+}
+
+/// Place a house on the board at the vertex
+///
+/// Checks for if a house can be placed following the rules as follows:
+///
+/// - A house must be on a vertex that is connected (adjacent) to a owned road.
+/// - A house must not have another house in any of the three adjacent vertices.
+pub fn place_house(
+    board: &mut GameBoard,
+    vert: &Vertex,
+    player: &mut Player,
+) -> Result<(), GameError> {
+    let player_id = player.id;
+
+    // Check if we have a house in an adjacent vertex.
+    let is_house_adjacent = vert.adjacent_vertices().iter().any(|vert| {
+        board
+            .verts
+            .get(vert)
+            .map_or(false, |val| val.vert_type != DevType::None)
+    });
+
+    // Check if we have a road on one of our adjacent edges.
+    let is_on_road = vert.adjacent_edges().iter().any(|edge| {
+        board.edges.get(edge).map_or(false, |val| {
+            val.edge_type == EdgeType::Road && val.owning_player == player_id
+        })
+    });
+
+    // Both values must be false in order to be a valid placement.
+    if !is_house_adjacent || !is_on_road {
+        return Err(GameError::InvalidLocation);
+    }
+
+    // Consume resources and purchase, awarding the player the development
+    purchase(PurchaseType::House, player, || {
+        board.verts.insert(
+            *vert,
+            GameVert {
+                vert_type: DevType::House,
+                owning_player: player_id,
+            },
+        );
+    })
+}
+
+/// Place a road on the board at the edge
+///
+/// Checks for if an edge can be placed following the rules as follows:
+///
+/// - A road must be on a edge with an adjacent edge being another road owned by the same player
+///
+/// or
+/// - A road must be on an edge with an adjacent vertex being a development such as a house or city.
+pub fn place_road(
+    board: &mut GameBoard,
+    edge: &Edge,
+    player: &mut Player,
+) -> Result<(), GameError> {
+    let player_id = player.id;
+
+    // Is there a road adjacent to this road?
+    let is_road_adjacent = edge.adjacent_edges().iter().any(|e| {
+        board.edges.get(e).map_or(false, |val| {
+            val.edge_type == EdgeType::Road && val.owning_player == player_id
+        })
+    });
+
+    // Do we have a owned and developed vertex adjacent to us?
+    let is_development_adjacent = edge.endpoints().iter().any(|v| {
+        board.verts.get(v).map_or(false, |val| {
+            val.vert_type != DevType::None && val.owning_player == player_id
+        })
+    });
+
+    // Either value must be false to be a valid placement
+    if !is_road_adjacent && !is_development_adjacent {
+        return Err(GameError::InvalidLocation);
+    }
+
+    purchase(PurchaseType::Road, player, || {
+        board.edges.insert(
+            *edge,
+            GameEdge {
+                edge_type: EdgeType::Road,
+                owning_player: player_id,
+            },
+        );
+    })
+}

--- a/src/core/collection.rs
+++ b/src/core/collection.rs
@@ -1,0 +1,8 @@
+//! A collection defines the operations required of the library in order to interface
+//! with application specific data storage methods.
+
+/// The collection trait that defines behavior needed from a data storage schema.
+pub trait Collection<C, T> {
+    /// The ability to set a coordinate in the schema, this can be thought of like assignment, or HashMap insert function.
+    fn set(&mut self, coord: C, data: T);
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,6 +1,7 @@
 //! Core implementations for grids of all types.
 
 pub mod algorithms;
+pub mod collection;
 pub mod grid;
 pub mod tile;
 pub mod transform;

--- a/src/hex/shape.rs
+++ b/src/hex/shape.rs
@@ -415,15 +415,12 @@ impl<T: Clone> HexShape<T> {
     }
 }
 
-#[allow(unused_imports)]
+#[cfg(test)]
 mod tests {
     use std::collections::HashMap;
 
     use super::*;
-    use crate::{
-        axial,
-        core::{collection::Collection, tile::Tile},
-    };
+    use crate::{axial, core::collection::Collection};
 
     struct MockCollection {
         tiles: HashMap<Axial, i32>,

--- a/src/hex/shape.rs
+++ b/src/hex/shape.rs
@@ -4,7 +4,10 @@ use ndarray::{array, Array, Array2};
 
 use crate::{
     axial,
-    core::transform::{Transform, Vector2D},
+    core::{
+        collection::Collection,
+        transform::{Transform, Vector2D},
+    },
     transform, vector2d,
 };
 
@@ -60,14 +63,14 @@ impl<T: Clone> HexShape<T> {
     ///
     /// /// shape_verts stores a triangle of size 1
     /// let shape_verts = vec![axial!(0, 0), axial!(0, 1), axial!(1, 0)];
-    /// let my_shape = HexShape::make_shape(&shape_verts, true, || Tile::new(Some(1)));
+    /// let my_shape = HexShape::make_shape(&shape_verts, true, |_| Tile::new(Some(1)));
     /// ```
     ///
     /// The algorithm *WILL* calculate its inequalities on EVERY point in the array. So, in example, if you have a point
     /// inside a shape, that point will still be calculated but will not change anything about the resultant inequality.
     pub fn make_shape<F>(points: &[Axial], square_bb: bool, mut constructor: F) -> Self
     where
-        F: FnMut() -> T,
+        F: FnMut(Axial) -> T,
     {
         // We cannot construct a shape with no points, return an empty shape.
         if points.is_empty() {
@@ -122,7 +125,7 @@ impl<T: Clone> HexShape<T> {
 
         // Construct tiles that the shape contains.
         for coord in hexes {
-            arr[[coord.q as usize, coord.r as usize]] = Some(constructor());
+            arr[[coord.q as usize, coord.r as usize]] = Some(constructor(coord));
         }
 
         HexShape::new(Some(arr), Some(transform))
@@ -139,11 +142,11 @@ impl<T: Clone> HexShape<T> {
     /// use gridava::hex::shape::HexShape;
     ///
     /// /// Creates a line of size 1, 0-1 inclusive, and sets the tiles to Some(1)
-    /// let my_shape = HexShape::make_line(1, 0, true, || Tile::new(Some(1)));
+    /// let my_shape = HexShape::make_line(1, 0, true, |_| Tile::new(Some(1)));
     /// ```
     pub fn make_line<F>(size: u32, rot_dir: i32, square_bb: bool, constructor: F) -> Self
     where
-        F: FnMut() -> T,
+        F: FnMut(Axial) -> T,
     {
         // Working in local space
         let vertex_a = axial!(0, 0);
@@ -162,11 +165,11 @@ impl<T: Clone> HexShape<T> {
     /// use gridava::hex::shape::HexShape;
     ///
     /// /// Creates a triangle of size 1, 0-1 inclusive, and sets the tiles to Some(1)
-    /// let my_shape = HexShape::make_triangle(1, 0, true, || Tile::new(Some(1)));
+    /// let my_shape = HexShape::make_triangle(1, 0, true, |_| Tile::new(Some(1)));
     /// ```
     pub fn make_triangle<F>(size: u32, rot_dir: i32, square_bb: bool, constructor: F) -> Self
     where
-        F: FnMut() -> T,
+        F: FnMut(Axial) -> T,
     {
         // Working in local space
         let vertex_a = axial!(0, 0);
@@ -187,11 +190,11 @@ impl<T: Clone> HexShape<T> {
     /// use gridava::hex::shape::HexShape;
     ///
     /// /// Creates a rhombus of size 1, 0-1 inclusive, and sets the tiles to Some(1)
-    /// let my_shape = HexShape::make_rhombus(1, 0, true, || Tile::new(Some(1)));
+    /// let my_shape = HexShape::make_rhombus(1, 0, true, |_| Tile::new(Some(1)));
     /// ```
     pub fn make_rhombus<F>(size: u32, rot_dir: i32, square_bb: bool, constructor: F) -> Self
     where
-        F: FnMut() -> T,
+        F: FnMut(Axial) -> T,
     {
         // Working in local space
         let vertex_a = axial!(0, 0);
@@ -201,6 +204,38 @@ impl<T: Clone> HexShape<T> {
 
         Self::make_shape(
             &[vertex_a, vertex_b, vertex_c, vertex_d],
+            square_bb,
+            constructor,
+        )
+    }
+
+    /// Create a hexagon shape.
+    ///
+    /// Given a size and direction this will create a regular hexagon.
+    ///
+    /// see [`Self::make_shape`] for more.
+    ///
+    /// ```
+    /// use gridava::core::tile::Tile;
+    /// use gridava::hex::shape::HexShape;
+    ///
+    /// /// Creates a hexagon of size 1, 0-1 inclusive, and sets the tiles to Some(1)
+    /// let my_shape = HexShape::make_hexagon(1, 0, true, |_| Tile::new(Some(1)));
+    /// ```
+    pub fn make_hexagon<F>(size: u32, rot_dir: i32, square_bb: bool, constructor: F) -> Self
+    where
+        F: FnMut(Axial) -> T,
+    {
+        // Working in local space
+        let vertex_a = axial!(size as i32, 0);
+        let vertex_b = vertex_a.make_vector(size as i32, rot_dir);
+        let vertex_c = vertex_b.make_vector(size as i32, rot_dir + 1);
+        let vertex_d = vertex_c.make_vector(size as i32, rot_dir + 2);
+        let vertex_e = vertex_d.make_vector(size as i32, rot_dir + 3);
+        let vertex_f = vertex_e.make_vector(size as i32, rot_dir + 4);
+
+        Self::make_shape(
+            &[vertex_a, vertex_b, vertex_c, vertex_d, vertex_e, vertex_f],
             square_bb,
             constructor,
         )
@@ -324,6 +359,23 @@ impl<T: Clone> HexShape<T> {
         self
     }
 
+    /// Apply a shape to a collection
+    ///
+    /// Transforms the coordinates according to the transform. before setting the data into the collection
+    ///
+    /// See the colony game example for a usecase.
+    pub fn apply_shape<COL: Collection<Axial, T>>(&self, col: &mut COL) {
+        self.shape.indexed_iter().for_each(|ele| {
+            if let Some(value) = ele.1.as_ref() {
+                // Apply transform
+                let coord =
+                    axial!(ele.0 .0 as i32, ele.0 .1 as i32).apply_transform(self.transform);
+
+                col.set(coord, value.clone());
+            }
+        });
+    }
+
     /// Get a reference to the shape's tile array.
     ///
     /// # Example
@@ -424,19 +476,19 @@ mod tests {
     #[test]
     fn make_shape() {
         assert_eq!(
-            HexShape::make_shape(&[], true, || 1),
+            HexShape::make_shape(&[], true, |_| 1),
             HexShape::new(None, None)
         );
 
         assert_eq!(
-            HexShape::make_shape(&[axial!(0, 0), axial!(2, 0)], false, || 1).get_hexes(),
+            HexShape::make_shape(&[axial!(0, 0), axial!(2, 0)], false, |_| 1).get_hexes(),
             Array::from_shape_simple_fn((3, 1), || Some(1))
         )
     }
 
     #[test]
     fn make_line() {
-        let default_tile_fn = &Tile::<i32>::default;
+        let default_tile_fn = |_| i32::default();
 
         assert_eq!(
             HexShape::make_line(0, 0, true, default_tile_fn),
@@ -467,19 +519,38 @@ mod tests {
     #[test]
     fn make_triangle() {
         assert_eq!(
-            HexShape::make_triangle(1, 0, true, || 1),
-            HexShape::make_shape(&[axial!(0, 0), axial!(1, 0), axial!(0, 1)], true, || 1)
+            HexShape::make_triangle(1, 0, true, |_| 1),
+            HexShape::make_shape(&[axial!(0, 0), axial!(1, 0), axial!(0, 1)], true, |_| 1)
         );
     }
 
     #[test]
     fn make_rhombus() {
         assert_eq!(
-            HexShape::make_rhombus(1, 0, true, || 1),
+            HexShape::make_rhombus(1, 0, true, |_| 1),
             HexShape::make_shape(
                 &[axial!(0, 0), axial!(1, 0), axial!(0, 1), axial!(1, 1)],
                 true,
-                || 1
+                |_| 1
+            )
+        );
+    }
+
+    #[test]
+    fn make_hexagon() {
+        assert_eq!(
+            HexShape::make_hexagon(1, 0, true, |_| 1),
+            HexShape::make_shape(
+                &[
+                    axial!(1, 0),
+                    axial!(2, 0),
+                    axial!(2, 1),
+                    axial!(1, 2),
+                    axial!(0, 2),
+                    axial!(0, 1)
+                ],
+                true,
+                |_| 1
             )
         );
     }
@@ -487,15 +558,15 @@ mod tests {
     #[test]
     fn scale() {
         assert_eq!(
-            HexShape::make_rhombus(1, 0, true, || 1).scale(vector2d!(2.0, 2.0)),
-            HexShape::make_rhombus(3, 0, true, || 1)
+            HexShape::make_rhombus(1, 0, true, |_| 1).scale(vector2d!(2.0, 2.0)),
+            HexShape::make_rhombus(3, 0, true, |_| 1)
         );
 
         assert_eq!(
-            HexShape::make_rhombus(1, 0, true, || 1)
+            HexShape::make_rhombus(1, 0, true, |_| 1)
                 .scale(vector2d!(2.0, 2.0))
                 .scale(vector2d!(0.5, 0.5)),
-            HexShape::make_rhombus(1, 0, true, || 1)
+            HexShape::make_rhombus(1, 0, true, |_| 1)
         );
     }
 
@@ -510,14 +581,14 @@ mod tests {
 
     #[test]
     fn set_hexes() {
-        let shape = HexShape::make_rhombus(1, 0, true, || 1);
+        let shape = HexShape::make_rhombus(1, 0, true, |_| 1);
         let new_arr = Array::from_shape_simple_fn((1, 1), || Some(1));
         assert_eq!(shape.set_hexes(new_arr.clone()).get_hexes(), new_arr);
     }
 
     #[test]
     fn get_hexes() {
-        let shape = HexShape::make_rhombus(1, 0, true, || 1);
+        let shape = HexShape::make_rhombus(1, 0, true, |_| 1);
         assert_eq!(
             shape.get_hexes(),
             Array::from_shape_simple_fn((2, 2), || Some(1))
@@ -526,7 +597,7 @@ mod tests {
 
     #[test]
     fn get_hexes_mut() {
-        let mut shape = HexShape::make_rhombus(1, 0, true, || 1);
+        let mut shape = HexShape::make_rhombus(1, 0, true, |_| 1);
         assert_eq!(
             shape.get_hexes_mut(),
             &mut Array::from_shape_simple_fn((2, 2), || Some(1))

--- a/src/hex/shape.rs
+++ b/src/hex/shape.rs
@@ -417,8 +417,23 @@ impl<T: Clone> HexShape<T> {
 
 #[allow(unused_imports)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
-    use crate::{axial, core::tile::Tile};
+    use crate::{
+        axial,
+        core::{collection::Collection, tile::Tile},
+    };
+
+    struct MockCollection {
+        tiles: HashMap<Axial, i32>,
+    }
+
+    impl Collection<Axial, i32> for MockCollection {
+        fn set(&mut self, coord: Axial, data: i32) {
+            self.tiles.insert(coord, data);
+        }
+    }
 
     #[test]
     fn translate() {
@@ -584,6 +599,21 @@ mod tests {
         let shape = HexShape::make_rhombus(1, 0, true, |_| 1);
         let new_arr = Array::from_shape_simple_fn((1, 1), || Some(1));
         assert_eq!(shape.set_hexes(new_arr.clone()).get_hexes(), new_arr);
+    }
+
+    #[test]
+    fn apply_shape() {
+        let mut col = MockCollection {
+            tiles: Default::default(),
+        };
+        HexShape::make_triangle(2, 0, true, |_| 1).apply_shape(&mut col);
+
+        for (coord, data) in HexShape::make_triangle(2, 0, true, |_| 1)
+            .get_hexes()
+            .indexed_iter()
+        {
+            assert!(col.tiles.get(&axial!(coord.0 as i32, coord.1 as i32)) == data.as_ref())
+        }
     }
 
     #[test]


### PR DESCRIPTION
Creating an example colony board game using the library API.

A few noteworthy changes, yet to be codified into ADR:
- A library level data storage schema, HexGrid, no longer exists.
    - Being able to pass around a reference of the storage schema into a function argument is quite a common occurrence and having to type out the generics as part of the type felt horrible. As such instead what is being done is there will be one or more trait definitions that serve as the adapter for the library to a storage schema for when that is needed. See `HexShape::apply_shape()` for an example https://github.com/algodiva/gridava/blob/ba8ca5f72e61410bd6b6932d33056817b9731357/src/hex/shape.rs#L367
- To facilitate worldspace to gridspace conversion in the absence of the HexGrid there will exist a helper struct that will allow conversion to and fro with a simple little struct.

resolves #46 
resolves #40 
